### PR TITLE
Add learning decay to the training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/train_data
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ rand_distr = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"
 rayon = "1.7.0"
+clap = { version = "4.3.1", features = ["derive"] }

--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -14,6 +14,7 @@ pub struct GPT<O: Optimizer, R: Rng> {
     rng: R,
     graph: Graph,
     vocab_size: usize,
+    lr_decay_iter: usize,
     num_tokens: usize,
     params: Vec<TensorId>,
     token_embedding: TensorId,
@@ -91,6 +92,7 @@ fn select<T: TensorOps<f32>>(t: &T) -> usize {
 impl<O: Optimizer, R: Rng> GPT<O, R> {
     pub fn new(
         mut rng: R,
+        lr_decay_iter: usize,
         vocab_size: usize,
         embedding_degree: usize,
         num_tokens: usize,
@@ -210,6 +212,7 @@ impl<O: Optimizer, R: Rng> GPT<O, R> {
         Self {
             rng,
             graph: g,
+            lr_decay_iter,
             vocab_size,
             num_tokens,
             params,
@@ -318,7 +321,7 @@ impl<O: Optimizer, R: Rng> GPT<O, R> {
             }
             let avg_loss = errs.iter().sum::<f32>() / errs.len() as f32;
             self.graph
-                .optimize(&mut self.optimizer, &self.params.iter().cloned().collect());
+                .optimize(&mut self.optimizer, self.lr_decay_iter, &self.params.iter().cloned().collect());
             if i % 50 == 0 {
                 println!("Saving the model...");
                 self.save();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -133,7 +133,7 @@ impl Graph {
         );
         child
     }
-    pub fn optimize<O: Optimizer>(&mut self, opt: &mut O, params: &HashSet<TensorId>) {
+    pub fn optimize<O: Optimizer>(&mut self, opt: &mut O, lr_decay_iter: usize, params: &HashSet<TensorId>) {
         let (params, grads): (Vec<&mut Tensor<f32>>, Vec<&Tensor<f32>>) = self
             .tensors
             .iter_mut()
@@ -145,6 +145,6 @@ impl Graph {
             .collect::<Vec<_>>()
             .into_iter()
             .unzip();
-        opt.step(params, grads);
+        opt.step(lr_decay_iter, params, grads);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,18 @@ use femto_gpt::tokenizer::{SimpleTokenizer, Tokenizer};
 
 use std::fs;
 use std::io::Write;
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    // learning rate decay iterations
+    #[arg(short, long, default_value_t = 0)]
+    lr_decay_iter: usize
+}
 
 fn main() {
+    let args = Cli::parse();
     let mut rng = rand::thread_rng();
 
     // Create a unique char-to-int mapping for all unique characters inside our dataset
@@ -30,6 +40,7 @@ fn main() {
 
     let mut gpt = GPT::new(
         &mut rng,
+        args.lr_decay_iter,
         vocab_size,
         embedding_degree,
         num_tokens,
@@ -37,7 +48,7 @@ fn main() {
         num_heads,
         head_size,
         dropout,
-        femto_gpt::optimizer::AdamW::new(0.00003),
+        femto_gpt::optimizer::AdamW::new(0.001),
     );
 
     println!("Number of parameters: {}", gpt.num_params());


### PR DESCRIPTION
Add learning decay to the training:
1) It's constant decay per step for given number of steps
2) Taken through command line argument (this way in future you can add more arguments as needed)
3) Increase the default learning rate to 0.001 which is the high end of adam lr since it can now decay to the min_lr specified in the optimizer settings.

PS: Changed gitignore to ignore the train_data folder and Cargo.lock file