### PR TITLE
impl `ByteTokenizer`

### DIFF
--- a/src/tokenizer/byte.rs
+++ b/src/tokenizer/byte.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 pub struct ByteTokenizer;
 
 impl ByteTokenizer {
-    pub fn new(_: &str) -> Self {
+    pub fn new() -> Self {
         ByteTokenizer
     }
 }

--- a/src/tokenizer/byte.rs
+++ b/src/tokenizer/byte.rs
@@ -1,0 +1,31 @@
+use super::Tokenizer;
+use std::collections::{HashMap, HashSet};
+
+pub struct ByteTokenizer;
+
+impl ByteTokenizer {
+    pub fn new(_: &str) -> Self {
+        ByteTokenizer
+    }
+}
+
+impl Tokenizer for ByteTokenizer {
+    fn vocab_size(&self) -> usize {
+        256
+    }
+    fn tokenize(&self, string: &str) -> Vec<usize> {
+        string
+            .as_bytes()
+            .iter()
+            .map(|b| *b as usize)
+            .collect()
+    }
+    fn untokenize(&self, tokens: &[usize]) -> String {
+        String::from_utf8_lossy(
+            &tokens
+                .iter()
+                .map(|b| *b as u8)
+                .collect::<Vec<u8>>())
+        .to_string()
+    }
+}

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -1,3 +1,6 @@
+mod byte;
+pub use byte::*;
+
 mod simple;
 pub use simple::*;
 


### PR DESCRIPTION
It's a tokenizer that simply converts a string to a utf-8 byte array and convert each byte to usize.

The biggest advantage of this tokenizer is that, unlike `SimpleTokenizer`, you can reuse a model even though dataset changes.

I have tested it and it works well. I didn't commit the changes in main.rs because I want to keep `SimpleTokenizer` as default.