### PR TITLE
Issue #11: Add more documentation/comments

### DIFF
--- a/src/funcs/embedding.rs
+++ b/src/funcs/embedding.rs
@@ -4,14 +4,38 @@ use crate::tensor::*;
 #[cfg(feature = "gpu")]
 use super::{gpu, GpuFunction, TensorId};
 
+/// A simple **embedding layer** that maps integer indices to float vectors.
+///
+/// The first input tensor contains indices (`usize`) and the second contains
+/// the embedding matrix (`f32`).
 #[derive(Debug, Clone)]
 pub struct Embedding;
 impl Embedding {
+    /// Creates a new `Embedding` layer wrapped in a `Box<dyn Function>`.
+    ///
+    /// # Example
+    /// ```example
+    /// let embed = Embedding::new();
+    /// ```
     pub fn new() -> Box<dyn Function> {
         Box::new(Self {})
     }
 }
+
 impl Function for Embedding {
+    /// Performs a forward pass of the embedding layer.
+    ///
+    /// # Arguments
+    /// * `inps` - A slice of references to `GeneralTensor`s. Expects:
+    ///     1. A tensor of indices (`usize`)
+    ///     2. A tensor of embedding vectors (`f32`) with shape `[vocab_size, embedding_dim]`
+    /// * `_training` - Indicates if the function is in training mode (not used here)
+    ///
+    /// # Returns
+    /// A `Tensor<f32>` containing the embedded vectors for the given indices.
+    ///
+    /// # Errors
+    /// Returns `TensorError::UnexpectedShape` if the embedding matrix is not 2D.
     fn run(
         &mut self,
         inps: &[&GeneralTensor],
@@ -24,6 +48,24 @@ impl Function for Embedding {
         }
         inp.map(0, |s| Ok(emb.get(s.scalar()?)?.into()))
     }
+
+    /// Computes gradients with respect to the input and embedding matrix.
+    ///
+    /// The gradient with respect to indices is a scalar zero (indices don't need gradients
+    /// as they are discrete). The gradient with respect to the embedding matrix is computed
+    /// by accumulating the output gradients at rows corresponding to the input indices.
+    ///
+    /// # Arguments
+    /// * `inps` - A slice of references to the input tensors (indices and embedding matrix)
+    /// * `out_grad` - The gradient tensor with respect to the output
+    ///
+    /// # Returns
+    /// A `Vec<Tensor<f32>>` containing:
+    ///     1. Gradient w.r.t. indices (always zero scalar)
+    ///     2. Gradient w.r.t. embedding matrix (updated rows only)
+    ///
+    /// # Errors
+    /// Returns `TensorError` if tensor operations fail during gradient computation.
     fn grad(
         &self,
         inps: &[&GeneralTensor],
@@ -41,6 +83,11 @@ impl Function for Embedding {
         }
         Ok(vec![Tensor::scalar(0.), grad])
     }
+
+    /// Creates a boxed clone of this embedding layer.
+    ///
+    /// # Returns
+    /// A new `Box<dyn Function>` containing a clone of this `Embedding`.
     fn clone_box(&self) -> Box<dyn Function> {
         Box::new(self.clone())
     }

--- a/src/funcs/gelu.rs
+++ b/src/funcs/gelu.rs
@@ -7,6 +7,17 @@ use super::{gpu, GpuFunction, TensorId};
 const SQRT_2_OVER_PI: f32 = 0.7978845608;
 const GELU_CONST: f32 = 0.044715;
 
+/// Computes the Gaussian Error Linear Unit (GELU) activation function.
+///
+/// GELU is a smooth, non-linear activation function that has been shown to work
+/// well in modern deep learning models, particularly in transformer architectures.
+/// It approximates the input multiplied by the cumulative distribution function
+/// of a Gaussian distribution.
+///
+/// The function uses the tanh-based approximation for computational efficiency:
+/// ```text
+/// GELU(x) = 0.5 * x * (tanh(sqrt(2/π) * (x + 0.044715 * x³)) + 1)
+/// ```
 fn gelu(x: f32) -> f32 {
     0.5 * x * ((SQRT_2_OVER_PI * (x + GELU_CONST * x.powi(3))).tanh() + 1.)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,75 @@
+//! **femtoGPT** is a pure Rust implementation of a minimal Generative Pretrained Transformer.
+//!
+//! It can be used for both *inference* and *training* of GPT-style language-models
+//! using **CPUs** and **GPUs**!
+//!
+//!
+//! ## Usage
+//!
+//! Training:
+//!
+//!`cargo run --release -- train`
+//!
+//! Inference:
+//!
+//! `cargo run --release -- infer`
+//!
+//! (Note: Add `--features gpu` in order to leverage GPU speedups!)
+//!
+//! ## Intro
+//!
+//! Everything is implemented from scratch, including the tensor processing logic
+//! along with training/inference code of a minimal GPT architecture.
+//!
+//! The architecture is very similar/almost identical with Andrej Karpathy's
+//![nanoGPT video lecture](https://github.com/karpathy/ng-video-lecture).
+//!
+//! femtoGPT is a great start for those who are fascinated by LLMs and would like to
+//! understand how these models work in very deep levels.
+//!
+//! femtoGPT uses nothing but random generation libraries (`rand`/`rand-distr`), data-serialization
+//! libraries (`serde`/`bincode` for saving/loading already trained models) and a
+//! parallel computing library (`rayon`).
+//!
+//! femtoGPT is ~~EXTREMELY SLOW~~ ***relatively fast on CPU 😉***, and most of the
+//! primitive operations (E.g Matrix multiplication) are implemented in the simplest way possible.
+//!
+//! Correctness of gradients is checked using gradient-check method, though it still is very
+//! possible that some layers are implemented wrongly.
+//!
+//! ([Discord server](https://discord.gg/wTJFaDVn45) for discussions around the project!)
+//!
+//! ## Usage
+//!
+//! Make sure you have the Rust toolchain on your system, in order to compile and run
+//! the project:
+//!
+//! `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+//!
+//! If you want to train using a GPU, you will first need to make sure your GPU drivers
+//! are correctly installed on your system, and their OpenCL runtimes are available.
+//!
+//! On Debian systems, you can setup OpenCL runtimes by installing the package `ocl-icd-opencl-dev`:
+//!
+//! `sudo apt install ocl-icd-opencl-dev`
+//!
+//! ***GOOD NEWS!*** *Since femtoGPT's GPU implementation is based on OpenCL, it can
+//! run on both NVIDIA and AMD cards, and you won't need to install heavy-weight
+//! CUDA-toolkits on your system. OpenCL runtimes would suffice!*
+//!
+//! Now you'll just need to put the text you want to train your GPT model on, inside
+//! `dataset.txt`. Make sure it has a small number of unique characters! (E.g. the
+//! current dataset has only used 65 different unique characters!)
+//!
+//! Then you'll need to run:
+//!
+//! ```example
+//! cargo run --release
+//! ```
+//!
+//!It will start training the model and will put the training data in the `train_data`
+//! directory. You can stop the training and continue later!
+//! 
 pub mod funcs;
 pub mod gpt;
 pub mod graph;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,14 +7,39 @@ use std::io::prelude::*;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+/// Command-line interface definition for the model training and inference application.
+///
+/// This enum defines two operational modes — [`Train`](Cli::Train) and [`Infer`](Cli::Infer) —
+/// that control how the program behaves.
+///
+/// (Note: Add `--features gpu` in order to leverage GPU speedups!)
+/// If you want to train using a GPU, you will first need to make sure your GPU drivers are correctly installed on your system, and their OpenCL runtimes are available.
 #[derive(StructOpt, Debug)]
 enum Cli {
+    /// **Training mode** — used to train or fine-tune a model on a given dataset.
+    ///
+    /// This mode reads a text dataset and updates or creates a serialized model state file.
+    /// Example:
+    /// ```bash
+    /// cargo run --release train --dataset dataset.txt --model training_state.dat
+    /// ```
     Train {
         #[structopt(long, default_value = "dataset.txt")]
         dataset: PathBuf,
         #[structopt(long, default_value = "training_state.dat")]
         model: PathBuf,
     },
+
+    /// **Inference mode** — used to generate predictions or text completions from a trained model.
+    ///
+    /// This mode loads a trained model and a tokenizer dataset, processes a given text prompt,
+    /// and outputs generated text samples.
+    ///
+    /// Example:
+    /// ```bash
+    /// cargo run --release infer --tokenizer-dataset dataset.txt --model training_state.dat \
+    ///     --prompt "Once upon a time" --count 5 --temperature 0.7
+    /// ```
     Infer {
         #[structopt(long, default_value = "dataset.txt")]
         tokenizer_dataset: PathBuf,
@@ -29,27 +54,40 @@ enum Cli {
     },
 }
 
+/// Entry point for femtoGPT
+///
+/// Depending on whether the `gpu` feature is enabled at compile time, the
+/// computation graph is constructed using either a CPU or GPU backend.
+///
+/// # Returns
+/// Returns `Ok(())` on success, or a [`GraphError`] if model initialization or computation fails.
+///
 fn main() -> Result<(), GraphError> {
+    // Choose CPU or GPU computation graph depending on feature flags.
     #[cfg(not(feature = "gpu"))]
     let graph = femto_gpt::graph::CpuGraph::new();
     #[cfg(not(feature = "gpu"))]
     let is_gpu = false;
 
     #[cfg(feature = "gpu")]
-    let graph = femto_gpt::graph::gpu::GpuGraph::new()?;
+    let graph = femto_gpt::graph::gpu::GpuGraph::new()?; // TODO: may fail if GPU not available, gracefully handle
     #[cfg(feature = "gpu")]
     let is_gpu = true;
 
-    let batch_size = 32;
-    let num_tokens = 64;
-    let embedding_degree = 64;
-    let num_layers = 4;
-    let num_heads = 4;
+    // Model hyperparameters
+    let batch_size = 32; // Number of samples processed in one training step.
+    let num_tokens = 64; // Maximum number of tokens per sequence.
+    let embedding_degree = 64; // Dimensionality of embedding vectors.
+    let num_layers = 4; // Number of transformer layers.
+    let num_heads = 4; // Number of attention heads.
     let head_size = embedding_degree / num_heads;
-    let dropout = 0.0;
+    let dropout = 0.0; // Dropout probability (disabled by default).
     assert_eq!(num_heads * head_size, embedding_degree);
 
+    // Parse CLI arguments to determine mode (Train / Infer)
     let cli = Cli::from_args();
+
+    // CLI Mode: Inference
     match cli {
         Cli::Infer {
             tokenizer_dataset,
@@ -63,14 +101,20 @@ fn main() -> Result<(), GraphError> {
             let mut rng = rand::thread_rng();
 
             // Create a unique char-to-int mapping for all unique characters inside our dataset
-            let dataset_char = fs::read_to_string(tokenizer_dataset)
-                .expect("Should have been able to read the file");
+            //
+            // The dataset is treated as a flat text corpus from which all unique characters
+            // will be extracted to define the vocabulary of the model.
+            let dataset_char = fs::read_to_string(tokenizer_dataset).expect(
+                "Failed to read tokenizer dataset file. Ensure the path exists and is readable.",
+            );
             let tokenizer = SimpleTokenizer::new(&dataset_char);
 
-            assert_eq!(num_heads * head_size, embedding_degree);
+            assert_eq!(num_heads * head_size, embedding_degree); // runtime sanity check to ensure transformer hyperparameters are consistent
 
+            // number of unique characters in the tokenizer vocabulary.
             let vocab_size = tokenizer.vocab_size();
             println!("Vocab-size: {} unique characters", vocab_size);
+            
             let mut gpt = GPT::new(
                 &mut rng,
                 graph,

--- a/src/tokenizer/simple.rs
+++ b/src/tokenizer/simple.rs
@@ -1,6 +1,25 @@
 use super::Tokenizer;
 use std::collections::{HashMap, HashSet};
 
+/// A minimal **character-level tokenizer** for converting between raw text and integer tokens.
+///
+/// The tokenizer scans a dataset to identify all **unique characters**, then builds two
+/// bidirectional lookup maps:
+///
+/// - `ch_to_int`: maps each character → integer token ID  
+/// - `int_to_ch`: maps each integer token ID → character
+///
+/// This ensures a deterministic and reversible mapping between text and token sequences.
+/// It is intentionally simple and efficient for small-scale or experimental GPT models.
+///
+/// # Example
+/// ```ignore
+/// let dataset = "Hello";
+/// let tokenizer = SimpleTokenizer::new(dataset);
+///
+/// Vocabulary size = 4 unique characters: {'H', 'e', 'l', 'o'}
+/// assert_eq!(tokenizer.vocab_size(), 4);
+/// ```
 pub struct SimpleTokenizer {
     vocab_size: usize,
     ch_to_int: HashMap<char, usize>,
@@ -34,9 +53,21 @@ impl SimpleTokenizer {
 }
 
 impl Tokenizer for SimpleTokenizer {
+    /// Returns the total number of unique characters in the tokenizer vocabulary.
     fn vocab_size(&self) -> usize {
         self.vocab_size
     }
+    /// Encodes a string into integer tokens using the internal `ch_to_int` mapping.
+    ///
+    /// # Panics
+    /// This function will panic if the string contains a character **not present**
+    /// in the tokenizer vocabulary.
+    ///
+    /// # Example
+    /// ```example
+    /// let tokenizer = SimpleTokenizer::new("abc");
+    /// assert_eq!(tokenizer.tokenize("cab"), vec![2, 0, 1]);
+    /// ```
     fn tokenize(&self, string: &str) -> Vec<usize> {
         string
             .chars()


### PR DESCRIPTION
Closes:  #11 - Add more documentation/comments

- Added detailed inline comments throughout the GPT module to explain key operations,
- Added Doc-Style Rust Comments (Library Documentation) `///` for `cargo doc` support.

- Documentation for the funcs module was intentionally deferred per previous discussion. I wish to work on this upon your approval.


_No functional changes—documentation only. All existing tests should pass without modification._